### PR TITLE
add a string in cryptlib.cpp, declared extern in config.h to hold the "e...

### DIFF
--- a/embeddedcryptopp/config.h
+++ b/embeddedcryptopp/config.h
@@ -1,6 +1,8 @@
 #ifndef CRYPTOPP_CONFIG_H
 #define CRYPTOPP_CONFIG_H
 
+extern const char*cryptopp_extra_version;
+
 // ***************** Important Settings ********************
 
 // define this if running on a big-endian CPU

--- a/embeddedcryptopp/cryptlib.cpp
+++ b/embeddedcryptopp/cryptlib.cpp
@@ -16,7 +16,14 @@
 
 #include <memory>
 
+#include "config.h"
+
+#include "extraversion.h"
+const char *cryptopp_extra_version = CRYPTOPP_EXTRA_VERSION;
+
 NAMESPACE_BEGIN(CryptoPP)
+
+const char *const cryptopp_extra_version = CRYPTOPP_EXTRA_VERSION;
 
 CRYPTOPP_COMPILE_ASSERT(sizeof(byte) == 1);
 CRYPTOPP_COMPILE_ASSERT(sizeof(word16) == 2);


### PR DESCRIPTION
...xtra version"

This way you can tell if the Crypto++ library you're linking/loading was built with patches (if the builder helpfully initialized this value for this purpose).
