### PR TITLE
invalid string key leads to uncaught BER decode error exception in C++ code

### DIFF
--- a/pycryptopp/test/test_rsa.py
+++ b/pycryptopp/test/test_rsa.py
@@ -52,6 +52,14 @@ class Signer(unittest.TestCase):
         self.failUnlessEqual(len(result), ((KEYSIZE+7)/8))
         # TODO: test against RSAInc. test vectors.
 
+    def test_create_from_string_invalid(self):
+        try:
+            signer = rsa.create_signing_key_from_string("invalid string")
+        except rsa.Error, le:
+            self.failUnless("decode error" in str(le), le)
+        else:
+            self.fail("Should have raised error from invalid string")
+
 class SignAndVerify(unittest.TestCase):
     def _help_test_sign_and_check(self, signer, verifier, msg):
         sig = signer.sign(msg)


### PR DESCRIPTION
make sure that creat_signing_key_from_string raises a Python exception, don't merge until pycryptopp actually does, or this test will fail
