### PR TITLE
A couple scripts for wheel building.

### DIFF
--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -8,8 +8,3 @@ set -e -x
 for PYBIN in /opt/python/cp2*/bin; do
     "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
-
-# Bundle external shared libraries into the wheels
-for whl in wheelhouse/*.whl; do
-    auditwheel repair "$whl" -w /io/wheelhouse/
-done

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copied straight from https://github.com/pypa/python-manylinux-demo
+
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-# Copied straight from https://github.com/pypa/python-manylinux-demo
+# Based on https://github.com/pypa/python-manylinux-demo
 
 set -e -x
 
 # Compile wheels
 for PYBIN in /opt/python/cp2*/bin; do
-    "${PYBIN}/pip" wheel /io/ -w /io/wheelhouse/
+    "${PYBIN}/pip" wheel /io/ -w /wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels and write them to their
+# final location.
+for whl in /wheelhouse/pycrypto-*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
 done

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -6,5 +6,5 @@ set -e -x
 
 # Compile wheels
 for PYBIN in /opt/python/cp2*/bin; do
-    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    "${PYBIN}/pip" wheel /io/ -w /io/wheelhouse/
 done

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -5,7 +5,7 @@
 set -e -x
 
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp2*/bin; do
     "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
 

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -6,7 +6,7 @@ set -e -x
 
 # Compile wheels
 for PYBIN in /opt/python/cp2*/bin; do
-    "${PYBIN}/pip" wheel /io/ -w /wheelhouse/
+    "${PYBIN}/pip" wheel --no-index --find-links file:///io/wheelhouse/ /io/ -w /wheelhouse/
 done
 
 # Bundle external shared libraries into the wheels and write them to their

--- a/misc/build_helpers/_build-wheels.sh
+++ b/misc/build_helpers/_build-wheels.sh
@@ -11,6 +11,6 @@ done
 
 # Bundle external shared libraries into the wheels and write them to their
 # final location.
-for whl in /wheelhouse/pycrypto-*.whl; do
+for whl in /wheelhouse/pycryptopp-*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done

--- a/misc/build_helpers/build-manylinux-wheels.sh
+++ b/misc/build_helpers/build-manylinux-wheels.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# This runs in the container to actually build the wheels.
+BUILDER="/io/misc/build_helpers/_build-wheels.sh"
+
+# This image can build x86_64 (64 bit) manylinux wheels.
+DOCKER_IMAGE="quay.io/pypa/manylinux1_x86_64"
+docker pull "${DOCKER_IMAGE}"
+docker run --rm -v "${PWD}:/io" "${DOCKER_IMAGE}" "${BUILDER}"
+
+# This image can build i686 (32 bit) manylinux wheels.
+DOCKER_IMAGE="quay.io/pypa/manylinux1_i686"
+docker pull "${DOCKER_IMAGE}"
+docker run --rm -v "${PWD}:/io" "${DOCKER_IMAGE}" linux32 "${BUILDER}"
+
+# Show the user what they built.
+ls wheelhouse

--- a/misc/build_helpers/build-manylinux-wheels.sh
+++ b/misc/build_helpers/build-manylinux-wheels.sh
@@ -3,15 +3,67 @@
 # This runs in the container to actually build the wheels.
 BUILDER="/io/misc/build_helpers/_build-wheels.sh"
 
+# Create a scratch path where a bunch of intermediate build state can be
+# dumped.
+BASE="$(mktemp -d)"
+
+# Put a virtualenv in there
+ENV="${BASE}/env"
+virtualenv "${ENV}"
+
+# Create a directory where we can dump wheels that the build depends on.
+WHEELHOUSE="${BASE}/wheelhouse"
+mkdir -p "${WHEELHOUSE}"
+
+# Helpers to run programs from the virtualenv - instead of "activating" it and
+# changing what "pip" and "python" mean for everything in the script.
+PYTHON="${ENV}/bin/python"
+PIP="${ENV}/bin/pip"
+
+
+# Get a new, good version of pip (who knows what version came with the
+# virtualenv on the system?)
+"${PIP}" install --upgrade pip
+
+# Dump the requirements into a pip-readable format.
+"${PYTHON}" setup.py egg_info
+
+# Get wheels for all of the requirements and dump them into the directory we
+# created for that purpose.
+"${PIP}" wheel \
+	 --requirement pycryptopp.egg-info/requires.txt \
+	 --wheel-dir "${WHEELHOUSE}"
+
 # This image can build x86_64 (64 bit) manylinux wheels.
 DOCKER_IMAGE="quay.io/pypa/manylinux1_x86_64"
 docker pull "${DOCKER_IMAGE}"
-docker run --rm -v "${PWD}:/io" "${DOCKER_IMAGE}" "${BUILDER}"
 
-# This image can build i686 (32 bit) manylinux wheels.
+# Build all the x86_64 bit wheels.  Give this image access to our working
+# directory (the root of the pycryptopp source tree).  Also give it access to
+# the wheelhouse we populated with our requirements above.  Also give it no
+# network access at all.  The image is (intentionally) full of super old
+# software that's riddled with vulnerabilities.  Cutting it off from the
+# network limits the attack surface to something a bit less terrifying.
+docker run \
+       --rm \
+       --network none \
+       --volume "${PWD}:/io" \
+       --volume "${WHEELHOUSE}:/io/wheelhouse" \
+       "${DOCKER_IMAGE}" \
+       "${BUILDER}"
+
+# As above, but for the i686 (32 bit) builds.
 DOCKER_IMAGE="quay.io/pypa/manylinux1_i686"
 docker pull "${DOCKER_IMAGE}"
-docker run --rm -v "${PWD}:/io" "${DOCKER_IMAGE}" linux32 "${BUILDER}"
+docker run \
+       --rm \
+       --network none \
+       --volume "${PWD}:/io" \
+       --volume "${WHEELHOUSE}:/io/wheelhouse" \
+       "${DOCKER_IMAGE}" \
+       linux32 "${BUILDER}"
 
-# Show the user what they built.
-ls wheelhouse
+# Get the pycryptopp wheels from the place they were dumped.
+mkdir -p wheelhouse
+cp -v "${WHEELHOUSE}"/pycryptopp-*.whl wheelhouse/
+sha256sum wheelhouse/*.whl


### PR DESCRIPTION
Fixes https://tahoe-lafs.org/trac/pycryptopp/ticket/106

This doesn't integrate with CI at all because travis wants AWS credentials so it can upload build artifacts to S3 and at the moment I don't have any such credentials to supply.  It seems like it might not be unreasonable to merely have the release engineer run this script as part of the release process.

I can look into CI more if that's particularly desired, though.