### PR TITLE
sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ if BUILD_DOUBLE_LOAD_TESTER:
     srcs.append('_doubleloadtester.cpp', )
 
 ext_modules.append(
-    Extension('pycryptopp._pycryptopp', extra_srcs + srcs, include_dirs=include_dirs, library_dirs=library_dirs, libraries=libraries, extra_link_args=extra_link_args, extra_compile_args=extra_compile_args, define_macros=define_macros, undef_macros=undef_macros)
+    Extension('pycryptopp._pycryptopp', sorted(extra_srcs) + srcs, include_dirs=include_dirs, library_dirs=library_dirs, libraries=libraries, extra_link_args=extra_link_args, extra_compile_args=extra_compile_args, define_macros=define_macros, undef_macros=undef_macros)
     )
 
 # python-ed25519
@@ -163,7 +163,7 @@ sources.extend([os.path.join("src-ed25519","supercop-ref",s)
                 if s.endswith(".c") and s!="test.c"])
 m = Extension("pycryptopp.publickey.ed25519._ed25519",
               include_dirs=[os.path.join("src-ed25519","supercop-ref")],
-              sources=sources)
+              sources=sorted(sources))
 ext_modules.append(m)
 
 

--- a/src-cryptopp/GNUmakefile
+++ b/src-cryptopp/GNUmakefile
@@ -413,7 +413,7 @@ endif # HAS_SOLIB_VERSION
 ###########################################################
 
 # List cryptlib.cpp first, then cpu.cpp, then integer.cpp to tame C++ static initialization problems.
-SRCS := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integer.cpp pch.cpp simple.cpp winpipes.cpp cryptlib_bds.cpp,$(wildcard *.cpp))
+SRCS := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integer.cpp pch.cpp simple.cpp winpipes.cpp cryptlib_bds.cpp,$(sort $(wildcard *.cpp)))
 
 # Need CPU for X86/X64/X32 and ARM
 ifeq ($(IS_X86)$(IS_X64)$(IS_ARM32)$(IS_ARM64),0000)


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.