### PR TITLE
Prepare Pycryptopp for Crypto++ changes for byte

### DIFF
--- a/src/pycryptopp/cipher/aesmodule.cpp
+++ b/src/pycryptopp/cipher/aesmodule.cpp
@@ -20,6 +20,9 @@ typedef int Py_ssize_t;
 #include <src-cryptopp/aes.h>
 #endif
 
+// https://github.com/weidai11/cryptopp/issues/442
+typedef unsigned char byte;
+
 static const char*const aes___doc__ = "_aes counter mode cipher\n\
 You are advised to run aes.start_up_self_test() after importing this module.";
 

--- a/src/pycryptopp/cipher/xsalsa20module.cpp
+++ b/src/pycryptopp/cipher/xsalsa20module.cpp
@@ -16,6 +16,9 @@ typedef int Py_ssize_t;
 #include <src-cryptopp/salsa.h>
 #endif
 
+// https://github.com/weidai11/cryptopp/issues/442
+typedef unsigned char byte;
+
 static const char* const xsalsa20__doc__ = "_xsalsa20 cipher";
 
 static PyObject *xsalsa20_error;

--- a/src/pycryptopp/hash/sha256module.cpp
+++ b/src/pycryptopp/hash/sha256module.cpp
@@ -21,6 +21,9 @@ typedef int Py_ssize_t;
 #include <src-cryptopp/filters.h>
 #endif
 
+// https://github.com/weidai11/cryptopp/issues/442
+typedef unsigned char byte;
+
 static const char*const sha256___doc__ = "_sha256 hash function";
 
 static PyObject *sha256_error;


### PR DESCRIPTION
The Crypto++ library is getting ready to change the scope of its definition for a byte. The short of it is, Crypto++ byte and C++17 std::byte can cause compile failures due to ambiguous resolutions; and the behavior of Crypto++ byte and std::byte are incompatible.

More information can be found at:

* [std::byte](https://www.cryptopp.com/wiki/Std::byte) on the Crypto++ wiki
* [Issue 442, Test C++17 byte change with dry runs from various projects](https://github.com/weidai11/cryptopp/issues/442)

Also see [Issue 42, Crypto++ and upcoming change for byte definition due to C++17](https://github.com/tahoe-lafs/pycryptopp/issues/42)